### PR TITLE
预览构建编译与上线编译的方式改成一致

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "eslint-plugin-promise": "^3.8.0",
     "eslint-plugin-standard": "^3.1.0",
     "eslint-plugin-vue": "^4.5.0",
+    "execa": "^0.11.0",
     "husky": "^1.0.0-rc.8",
     "mip2": "^1.2.0"
   }

--- a/tools/build-site.js
+++ b/tools/build-site.js
@@ -7,7 +7,7 @@ const path = require('path')
 const async = require('async')
 const fs = require('fs-extra')
 const glob = require('glob')
-const builder = require('../node_modules/mip2/lib/build')
+const execa = require('execa')
 const rootDir = path.join(__dirname, '..')
 
 // 编译，结束后生成预览站点
@@ -23,22 +23,20 @@ function buildComponents () {
     return
   }
 
-  const build = async function (proj) {
+  const build = function (proj, done) {
     let src = path.join(rootDir, 'sites', proj)
     let dist = path.join(rootDir, 'dist', proj)
     let publicPath = '/' + proj
 
-    try {
-      await builder({
-        dir: src,
-        output: dist,
-        asset: publicPath,
-        clean: true
+    let options = ['build', '--dir', src, '--output', dist, '--asset', publicPath, '--clean']
+    execa('mip2', options)
+      .then(res => {
+        done()
       })
-    } catch (e) {
-      console.log(e)
-      process.exit(1)
-    }
+      .catch(err => {
+        console.log(err)
+        process.exit(1)
+      })
   }
 
   console.log('Building... Please wait')


### PR DESCRIPTION
当前预览的编译，直接用 require 的方式调用 build 模块，这种方式缺少了检查 npm 白名单的流程，导致编译结果和上线编译存在差异。因此改成一致。